### PR TITLE
SP-18943 - Bugfix: Apply expressions in multiple steps

### DIFF
--- a/LinqToElasticSearch.IntegrationTests/Clauses/WhereByTypes/WhereStringTests.cs
+++ b/LinqToElasticSearch.IntegrationTests/Clauses/WhereByTypes/WhereStringTests.cs
@@ -51,7 +51,7 @@ namespace LinqToElasticSearch.IntegrationTests.Clauses.WhereByTypes
         public void WhereStringContains()
         {
             //Given
-            var datas = Fixture.CreateMany<SampleData>().ToList();
+            var datas = Fixture.CreateMany<SampleData>(2).ToList();
 
             datas[0].Name = "abd";
             datas[1].Name = "abcdefgh";

--- a/LinqToElasticSearch.IntegrationTests/Clauses/WhereByTypes/WhereTimeTests.cs
+++ b/LinqToElasticSearch.IntegrationTests/Clauses/WhereByTypes/WhereTimeTests.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Linq;
+using AutoFixture;
+using FluentAssertions;
+using Xunit;
+
+namespace LinqToElasticSearch.IntegrationTests.Clauses.WhereByTypes
+{
+    public class WhereTimeTests : IntegrationTestsBase<SampleData>
+    {
+        [Fact]
+        public void WhereTimeEqual()
+        {
+            //Given
+            var samples = Fixture.CreateMany<SampleData>().ToList();
+            Bulk(samples);
+
+            ElasticClient.Indices.Refresh();
+
+            //When
+            var results = Sut.Where(x => x.TimeSpan == samples[1].TimeSpan);
+            var listResults = results.ToList();
+
+            //Then
+            listResults.Count.Should().Be(1);
+            listResults[0].Id.Should().Be(samples[1].Id);
+        }
+
+        [Fact]
+        public void WhereTimeNotEqual()
+        {
+            //Given
+            var samples = Fixture.CreateMany<SampleData>().ToList();
+            Bulk(samples);
+
+            ElasticClient.Indices.Refresh();
+
+            //When
+            var results = Sut.Where(x => x.TimeSpan != samples[1].TimeSpan);
+            var listResults = results.ToList();
+
+            //Then
+            listResults.Count.Should().Be(2);
+            listResults[0].Id.Should().Be(samples[0].Id);
+            listResults[1].Id.Should().Be(samples[2].Id);
+        }
+
+        [Fact]
+        public void WhereTimeGreaterThen()
+        {
+            //Given
+            var samples = Fixture.CreateMany<SampleData>().ToList();
+
+            var timeSpan = Fixture.Create<TimeSpan>();
+
+            samples[0].TimeSpan = timeSpan;
+            samples[1].TimeSpan = timeSpan.Add(TimeSpan.FromMinutes(5));
+            samples[2].TimeSpan = timeSpan.Subtract(TimeSpan.FromMinutes(5));
+
+            Bulk(samples);
+
+            ElasticClient.Indices.Refresh();
+
+            //When
+            var results = Sut.Where(x => x.TimeSpan > timeSpan).ToList();
+
+            //Then
+            results.Count.Should().Be(1);
+            results[0].TimeSpan.Should().Be(samples[1].TimeSpan);
+        }
+
+        [Fact]
+        public void WhereTimeGreaterThanOrEqual()
+        {
+            //Given
+            var samples = Fixture.CreateMany<SampleData>().ToList();
+
+            var timeSpan = Fixture.Create<TimeSpan>();
+
+            samples[0].TimeSpan = timeSpan;
+            samples[1].TimeSpan = timeSpan.Add(TimeSpan.FromMinutes(5));
+            samples[2].TimeSpan = timeSpan.Subtract(TimeSpan.FromMinutes(5));
+
+            Bulk(samples);
+
+            ElasticClient.Indices.Refresh();
+
+            //When
+            var results = Sut.Where(x => x.TimeSpan >= timeSpan).ToList();
+
+            //Then
+            results.Count.Should().Be(2);
+            results[0].TimeSpan.Should().Be(samples[0].TimeSpan);
+            results[1].TimeSpan.Should().Be(samples[1].TimeSpan);
+        }
+
+        [Fact]
+        public void WhereTimeLessThan()
+        {
+            //Given
+            var samples = Fixture.CreateMany<SampleData>().ToList();
+
+            var timeSpan = Fixture.Create<TimeSpan>();
+
+            samples[0].TimeSpan = timeSpan;
+            samples[1].TimeSpan = timeSpan.Add(TimeSpan.FromMinutes(5));
+            samples[2].TimeSpan = timeSpan.Subtract(TimeSpan.FromMinutes(5));
+
+            Bulk(samples);
+
+            ElasticClient.Indices.Refresh();
+
+            //When
+            var results = Sut.Where(x => x.TimeSpan < timeSpan).ToList();
+
+            //Then
+            results.Count.Should().Be(1);
+            results[0].TimeSpan.Should().Be(samples[2].TimeSpan);
+        }
+
+        [Fact]
+        public void WhereTimeLessThanOrEqual()
+        {
+            //Given
+            var samples = Fixture.CreateMany<SampleData>().ToList();
+
+            var timeSpan = Fixture.Create<TimeSpan>();
+
+            samples[0].TimeSpan = timeSpan;
+            samples[1].TimeSpan = timeSpan.Add(TimeSpan.FromMinutes(5));
+            samples[2].TimeSpan = timeSpan.Subtract(TimeSpan.FromMinutes(5));
+
+            Bulk(samples);
+
+            ElasticClient.Indices.Refresh();
+
+            //When
+            var results = Sut.Where(x => x.TimeSpan <= timeSpan).ToList();
+
+            //Then
+            results.Count.Should().Be(2);
+            results[0].TimeSpan.Should().Be(samples[0].TimeSpan);
+            results[1].TimeSpan.Should().Be(samples[2].TimeSpan);
+        }
+    }
+}

--- a/LinqToElasticSearch.IntegrationTests/MainFrom/MainFromTests.cs
+++ b/LinqToElasticSearch.IntegrationTests/MainFrom/MainFromTests.cs
@@ -286,18 +286,11 @@ namespace LinqToElasticSearch.IntegrationTests.MainFrom
             };
 
             var items = Fixture.CreateMany<SampleData>(4).ToList();
-            // tenho acesso
             items[0].FolderId = allowedFolders[0];
             items[0].TypeId = allowedTypes[0];
-            
-            // tenho acesso
             items[1].FolderId = allowedFolders[2];
-            
-            // tenho acesso
             items[2].FolderId = null;
             items[2].TypeId = allowedTypes[1];
-            
-            // nao tenho acesso
             items[3].FolderId = null;
 
             Bulk(items);
@@ -318,8 +311,10 @@ namespace LinqToElasticSearch.IntegrationTests.MainFrom
                 )
                 .OrderBy(x => x.Id);
 
-            byElastic.ToList().Should().HaveCount(1);
-            byMemory.ToList().Should().HaveCount(1);
+            byElastic.Should().HaveCount(1);
+            byElastic.ToList()[0].Id.Should().Be(items[0].Id);
+            byMemory.Should().HaveCount(1);
+            byMemory.ToList()[0].Id.Should().Be(items[0].Id);
         }
         
         [Fact]
@@ -339,18 +334,11 @@ namespace LinqToElasticSearch.IntegrationTests.MainFrom
             };
 
             var items = Fixture.CreateMany<SampleData>(4).ToList();
-            // tenho acesso
             items[0].FolderId = allowedFolders[0];
             items[0].TypeId = allowedTypes[0];
-            
-            // tenho acesso
             items[1].FolderId = allowedFolders[2];
-            
-            // tenho acesso
             items[2].FolderId = null;
             items[2].TypeId = allowedTypes[1];
-            
-            // nao tenho acesso
             items[3].FolderId = null;
 
             Bulk(items);
@@ -371,8 +359,8 @@ namespace LinqToElasticSearch.IntegrationTests.MainFrom
                 )
                 .OrderBy(x => x.Id);
 
-            byElastic.ToList().Should().HaveCount(0);
-            byMemory.ToList().Should().HaveCount(0);
+            byElastic.Should().HaveCount(0);
+            byMemory.Should().HaveCount(0);
         }
         
         [Fact]
@@ -392,18 +380,11 @@ namespace LinqToElasticSearch.IntegrationTests.MainFrom
             };
 
             var items = Fixture.CreateMany<SampleData>(4).ToList();
-            // tenho acesso
             items[0].FolderId = allowedFolders[0];
             items[0].TypeId = allowedTypes[0];
-            
-            // tenho acesso
             items[1].FolderId = allowedFolders[2];
-            
-            // tenho acesso
             items[2].FolderId = null;
             items[2].TypeId = allowedTypes[1];
-            
-            // nao tenho acesso
             items[3].FolderId = null;
 
             Bulk(items);
@@ -426,8 +407,10 @@ namespace LinqToElasticSearch.IntegrationTests.MainFrom
                 )
                 .OrderBy(x => x.Id);
 
-            byElastic.ToList().Should().HaveCount(1);
-            byMemory.ToList().Should().HaveCount(1);
+            byElastic.Should().HaveCount(1);
+            byElastic.ToList()[0].Id.Should().Be(items[0].Id);
+            byMemory.Should().HaveCount(1);
+            byMemory.ToList()[0].Id.Should().Be(items[0].Id);
         }
         
         [Theory]

--- a/LinqToElasticSearch.IntegrationTests/MainFrom/MainFromTests.cs
+++ b/LinqToElasticSearch.IntegrationTests/MainFrom/MainFromTests.cs
@@ -450,5 +450,78 @@ namespace LinqToElasticSearch.IntegrationTests.MainFrom
             // Then
             CompareAsJson(byElastic, byMemory);
         }
+        
+        [Fact]
+        public void WhereWithAllClauseAndEqualExpression()
+        {
+            // Given
+            var email = Fixture.Create<string>();
+            
+            var samples = Fixture.CreateMany<SampleData>().ToList();
+            samples[1].Emails[0] = email;
+            samples[1].Emails[1] = email;
+            samples[1].Emails[2] = email;
+
+            // When
+            Bulk(samples);
+            ElasticClient.Indices.Refresh();
+            
+            var byElastic = Sut.Where(x => x.Emails.All(y => y == email))
+                .ToList();
+            
+            var byMemory = samples.Where(x => x.Emails.All(y => y == email))
+                .ToList();
+
+            // Then
+            CompareAsJson(byElastic, byMemory);
+        }
+        
+        [Fact]
+        public void WhereWithAllClauseAndNotEqualExpression()
+        {
+            // Given
+            var email = Fixture.Create<string>();
+            
+            var samples = Fixture.CreateMany<SampleData>().ToList();
+            samples[1].Emails[0] = email;
+            samples[1].Emails[1] = email;
+            samples[1].Emails[2] = email;
+
+            // When
+            Bulk(samples);
+            ElasticClient.Indices.Refresh();
+            
+            var byElastic = Sut.Where(x => x.Emails.All(y => y != email))
+                .ToList();
+            
+            var byMemory = samples.Where(x => x.Emails.All(y => y != email))
+                .ToList();
+
+            // Then
+            CompareAsJson(byElastic, byMemory);
+        }
+        
+        [Fact]
+        public void WhereWithAllClauseAndNotEqualExpression2()
+        {
+            // Given
+            var email = Fixture.Create<string>();
+            
+            var samples = Fixture.CreateMany<SampleData>().ToList();
+            samples[1].Emails[0] = email;
+
+            // When
+            Bulk(samples);
+            ElasticClient.Indices.Refresh();
+            
+            var byElastic = Sut.Where(x => x.Emails.All(y => y != email))
+                .ToList();
+            
+            var byMemory = samples.Where(x => x.Emails.All(y => y != email))
+                .ToList();
+
+            // Then
+            CompareAsJson(byElastic, byMemory);
+        }
     }
 }

--- a/LinqToElasticSearch.IntegrationTests/MainFrom/MainFromTests.cs
+++ b/LinqToElasticSearch.IntegrationTests/MainFrom/MainFromTests.cs
@@ -269,6 +269,167 @@ namespace LinqToElasticSearch.IntegrationTests.MainFrom
             CompareAsJson(byElastic, byMemory);
         }
 
+        [Fact]
+        public void WhereWithThreeConditionsUsingContainAndExtrinsicComparisonWithFoundValue()
+        {
+            var allowedFolders = new List<Guid>
+            {
+                Fixture.Create<Guid>(),
+                Fixture.Create<Guid>(),
+                Fixture.Create<Guid>()
+            };
+
+            var allowedTypes = new List<Guid>
+            {
+                Fixture.Create<Guid>(),
+                Fixture.Create<Guid>()
+            };
+
+            var items = Fixture.CreateMany<SampleData>(4).ToList();
+            // tenho acesso
+            items[0].FolderId = allowedFolders[0];
+            items[0].TypeId = allowedTypes[0];
+            
+            // tenho acesso
+            items[1].FolderId = allowedFolders[2];
+            
+            // tenho acesso
+            items[2].FolderId = null;
+            items[2].TypeId = allowedTypes[1];
+            
+            // nao tenho acesso
+            items[3].FolderId = null;
+
+            Bulk(items);
+            ElasticClient.Indices.Refresh();
+
+            var byElastic = Sut.Where(x => x.Name == items[0].Name);
+            var byMemory = Sut.Where(x => x.Name == items[0].Name);
+
+            byElastic = byElastic.Where(item =>
+                    (item.FolderId == null && (false || allowedTypes.Contains(item.TypeId)))
+                    || (item.FolderId != null && allowedFolders.Contains(item.FolderId.Value))
+                )
+                .OrderBy(x => x.Id);
+
+            byMemory = byMemory.Where(item =>
+                    (item.FolderId == null && (false || allowedTypes.Contains(item.TypeId)))
+                    || (item.FolderId != null && allowedFolders.Contains(item.FolderId.Value))
+                )
+                .OrderBy(x => x.Id);
+
+            byElastic.ToList().Should().HaveCount(1);
+            byMemory.ToList().Should().HaveCount(1);
+        }
+        
+        [Fact]
+        public void WhereWithThreeConditionsUsingContainAndExtrinsicComparisonWithoutFoundValue()
+        {
+            var allowedFolders = new List<Guid>
+            {
+                Fixture.Create<Guid>(),
+                Fixture.Create<Guid>(),
+                Fixture.Create<Guid>()
+            };
+
+            var allowedTypes = new List<Guid>
+            {
+                Fixture.Create<Guid>(),
+                Fixture.Create<Guid>()
+            };
+
+            var items = Fixture.CreateMany<SampleData>(4).ToList();
+            // tenho acesso
+            items[0].FolderId = allowedFolders[0];
+            items[0].TypeId = allowedTypes[0];
+            
+            // tenho acesso
+            items[1].FolderId = allowedFolders[2];
+            
+            // tenho acesso
+            items[2].FolderId = null;
+            items[2].TypeId = allowedTypes[1];
+            
+            // nao tenho acesso
+            items[3].FolderId = null;
+
+            Bulk(items);
+            ElasticClient.Indices.Refresh();
+
+            var byElastic = Sut.Where(x => x.Name == items[3].Name);
+            var byMemory = Sut.Where(x => x.Name == items[3].Name);
+
+            byElastic = byElastic.Where(item =>
+                    (item.FolderId == null && (false || allowedTypes.Contains(item.TypeId)))
+                    || (item.FolderId != null && allowedFolders.Contains(item.FolderId.Value))
+                )
+                .OrderBy(x => x.Id);
+
+            byMemory = byMemory.Where(item =>
+                    (item.FolderId == null && (false || allowedTypes.Contains(item.TypeId)))
+                    || (item.FolderId != null && allowedFolders.Contains(item.FolderId.Value))
+                )
+                .OrderBy(x => x.Id);
+
+            byElastic.ToList().Should().HaveCount(0);
+            byMemory.ToList().Should().HaveCount(0);
+        }
+        
+        [Fact]
+        public void WhereWithFourConditionsUsingContainAndExtrinsicComparison()
+        {
+            var allowedFolders = new List<Guid>
+            {
+                Fixture.Create<Guid>(),
+                Fixture.Create<Guid>(),
+                Fixture.Create<Guid>()
+            };
+
+            var allowedTypes = new List<Guid>
+            {
+                Fixture.Create<Guid>(),
+                Fixture.Create<Guid>()
+            };
+
+            var items = Fixture.CreateMany<SampleData>(4).ToList();
+            // tenho acesso
+            items[0].FolderId = allowedFolders[0];
+            items[0].TypeId = allowedTypes[0];
+            
+            // tenho acesso
+            items[1].FolderId = allowedFolders[2];
+            
+            // tenho acesso
+            items[2].FolderId = null;
+            items[2].TypeId = allowedTypes[1];
+            
+            // nao tenho acesso
+            items[3].FolderId = null;
+
+            Bulk(items);
+            ElasticClient.Indices.Refresh();
+
+            var byElastic = Sut.Where(x => x.Name == items[0].Name);
+            var byMemory = Sut.Where(x => x.Name == items[0].Name);
+
+            byElastic = byElastic.Where(item => item.Age == items[0].Age);
+                
+            byElastic = byElastic.Where(item =>
+                    (item.FolderId == null && (false || allowedTypes.Contains(item.TypeId)))
+                    || (item.FolderId != null && allowedFolders.Contains(item.FolderId.Value))
+                )
+                .OrderBy(x => x.Id);
+
+            byMemory = byMemory.Where(item =>
+                    (item.FolderId == null && (false || allowedTypes.Contains(item.TypeId)))
+                    || (item.FolderId != null && allowedFolders.Contains(item.FolderId.Value))
+                )
+                .OrderBy(x => x.Id);
+
+            byElastic.ToList().Should().HaveCount(1);
+            byMemory.ToList().Should().HaveCount(1);
+        }
+        
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/LinqToElasticSearch.IntegrationTests/MainFrom/MainFromTests.cs
+++ b/LinqToElasticSearch.IntegrationTests/MainFrom/MainFromTests.cs
@@ -452,6 +452,29 @@ namespace LinqToElasticSearch.IntegrationTests.MainFrom
         }
         
         [Fact]
+        public void WhereWithAnyAndContainsExpression()
+        {
+            // Given
+            var samples = Fixture.CreateMany<SampleData>().ToList();
+            var searchEmail = samples[1].Emails[1][..^1];
+
+            // When
+            Bulk(samples);
+            ElasticClient.Indices.Refresh();
+            
+            var byElastic = Sut.Where(x => x.Emails.Any(y => y.Contains(searchEmail)))
+                .ToList();
+            
+            var byMemory = samples.Where(x => x.Emails.Any(y => y.Contains(searchEmail)))
+                .ToList();
+
+            // Then
+            byElastic.Should().HaveCount(1);
+            byElastic[0].Id.Should().Be(samples[1].Id);
+            CompareAsJson(byElastic, byMemory);
+        }
+        
+        [Fact]
         public void WhereWithAllClauseAndEqualExpression()
         {
             // Given

--- a/LinqToElasticSearch.IntegrationTests/SampleData.cs
+++ b/LinqToElasticSearch.IntegrationTests/SampleData.cs
@@ -11,24 +11,17 @@ namespace LinqToElasticSearch.IntegrationTests
         public string Name { get; set; }
         public string LastName { get; set; }
         public int Age { get; set; }
-
         public DateTime Date { get; set; }
-        
         public DateTime? Date1 { get; set; }
-        
         public SampleType SampleTypeProperty { get; set; }
-        
+        public SampleType? EnumNullable { get; set; }
         public Guid? FolderId { get; set; }
         public Guid TypeId { get; set; }
-        
-        [Keyword]
-        public IList<string> Emails { get; set; }
-        
-        [StringEnum]
-        [Keyword]
-        public SampleType SampleTypePropertyString { get; set; }
-        
         public bool Can { get; set; }
+        public TimeSpan TimeSpan { get; set; }
+        public TimeSpan? TimeSpanNullable { get; set; }
+        [Keyword] public IList<string> Emails { get; set; }
+        [StringEnum] [Keyword] public SampleType SampleTypePropertyString { get; set; }
     }
 
     public enum SampleType

--- a/LinqToElasticSearch/ElasticGeneratorQueryModelVisitor.cs
+++ b/LinqToElasticSearch/ElasticGeneratorQueryModelVisitor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
+using Nest;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
@@ -49,7 +50,22 @@ namespace LinqToElasticSearch
         {
             var tree = new GeneratorExpressionTreeVisitor<TU>(_propertyNameInferrerParser);
             tree.Visit(whereClause.Predicate);
-            QueryAggregator.Query = tree.QueryMap[whereClause.Predicate];
+            if (QueryAggregator.Query == null)
+            {
+                QueryAggregator.Query = tree.QueryMap[whereClause.Predicate];
+            }
+            else
+            {
+                var left = QueryAggregator.Query;
+                var right = tree.QueryMap[whereClause.Predicate];
+
+                var query = new BoolQuery
+                {
+                    Must = new[] { left, right }
+                };
+
+                QueryAggregator.Query = query;
+            }
             base.VisitWhereClause(whereClause, queryModel, index);
         }
         

--- a/LinqToElasticSearch/GeneratorExpressionTreeVisitor.cs
+++ b/LinqToElasticSearch/GeneratorExpressionTreeVisitor.cs
@@ -180,24 +180,20 @@ namespace LinqToElasticSearch
                         QueryMap[expression] = ParseQuery(query);
                         break;
                     case AnyResultOperator anyResultOperator:
+                        Visit(expression.QueryModel.MainFromClause.FromExpression);
+
                         var whereClauses = expression.QueryModel.BodyClauses.OfType<WhereClause>().ToList();
 
+                        if (whereClauses.Count > 1)
+                        {
+                            return base.VisitSubQuery(expression); // Throws. Only one expression is supported.
+                        }
+                        
                         foreach (var whereClause in whereClauses)
                         {
                             Visit(whereClause.Predicate);
+                            QueryMap[expression] = QueryMap[whereClause.Predicate];
                         }
-
-                        Visit(expression.QueryModel.MainFromClause.FromExpression);
-
-                        query = new TermsQuery
-                        {
-                            Field = PropertyName,
-                            Name = PropertyName,
-                            IsVerbatim = true,
-                            Terms = new[] { Value }
-                        };
-
-                        QueryMap[expression] = ParseQuery(query);
                         break;
                     case AllResultOperator allResultOperator:
                         Visit(allResultOperator.Predicate);

--- a/LinqToElasticSearch/GeneratorExpressionTreeVisitor.cs
+++ b/LinqToElasticSearch/GeneratorExpressionTreeVisitor.cs
@@ -667,10 +667,17 @@ namespace LinqToElasticSearch
         private object ConvertEnumValue(Type entityType, string propertyName, object value)
         {
             var enumValue = Enum.Parse(PropertyType, value.ToString());
+            
             var prop = entityType.GetProperties().FirstOrDefault(x => x.Name.ToLower() == propertyName.ToLower());
 
-            if (prop != null && prop.GetCustomAttributes(true)
-                    .Any(attribute => attribute is StringEnumAttribute && prop.PropertyType.IsEnum))
+            if (prop == null)
+            {
+                return (int)enumValue;
+            }
+            
+            var propType = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+            
+            if (prop.GetCustomAttributes(true).Any(attribute => attribute is StringEnumAttribute && propType.IsEnum))
             {
                 return enumValue.ToString();
             }

--- a/LinqToElasticSearch/LinqToElasticSearch.csproj
+++ b/LinqToElasticSearch/LinqToElasticSearch.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Elasticsearch.Net" Version="7.17.4" />
     <PackageReference Include="NEST" Version="7.13.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Remotion.Linq" Version="2.1.2" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.0" />
   </ItemGroup>

--- a/LinqToElasticSearch/TimeSpanConverter.cs
+++ b/LinqToElasticSearch/TimeSpanConverter.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace LinqToElasticSearch
+{
+    public class TimeSpanConverter : JsonConverter<TimeSpan>
+    {
+        public override void WriteJson(JsonWriter writer, TimeSpan value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.Ticks);
+        }
+
+        public override TimeSpan ReadJson(JsonReader reader, Type objectType, TimeSpan existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.Value == null || reader.ValueType == null || reader.ValueType != typeof(long))
+            {
+                return default;
+            }
+
+            return new TimeSpan((long)reader.Value);
+        }
+    }
+    
+    public class TimeSpanNullableConverter : JsonConverter<TimeSpan?>
+    {
+        public override void WriteJson(JsonWriter writer, TimeSpan? value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value?.Ticks);
+        }
+
+        public override TimeSpan? ReadJson(JsonReader reader, Type objectType, TimeSpan? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.Value == null || reader.ValueType == null || reader.ValueType != typeof(long))
+            {
+                return null;
+            }
+
+            return new TimeSpan((long)reader.Value);
+        }
+    }
+}

--- a/README.MD
+++ b/README.MD
@@ -24,10 +24,11 @@ This Library has compatibility with Elasticsearch .Net & NEST Client and Elastic
 # Support Clauses with Integration Tests
 * Select
 * Where
-  * Where(x => x.Any(exp))
-  * Where(x => x.Contains(exp))
-  * Where(x => x.StartsWith(exp))
-  * Where(x => x.EndsWith(exp))
+  * Where(x => x.Any(single expression))
+  * Where(x => x.All(single expression))
+  * Where(x => x.Contains(string))
+  * Where(x => x.StartsWith(string))
+  * Where(x => x.EndsWith(string))
 * OrderBy
 * Skip
 * Take


### PR DESCRIPTION
@pperboires a implementação feita pelo @edsonbonfim está funcional, porém ao aplicar filtros em duas etapas, o primeiro filtro era substituído.

![image](https://user-images.githubusercontent.com/30120305/217043546-7b8b25bb-20db-423d-9503-e5adaa489cae.png)

O branch foi derivado a partir da tarefa MC-1131 que está com PR aberto
